### PR TITLE
Update .gitignore

### DIFF
--- a/wangle/.gitignore
+++ b/wangle/.gitignore
@@ -5,6 +5,6 @@ Makefile
 Testing/
 cmake_install.cmake
 install_manifest.txt
-gmock/
+gtest/
 bin/
 lib/


### PR DESCRIPTION
Fixes build since googlecode.com stopped hosting projects & GMock was absorbed into GoogleTest. Uses GoogleTest Git repo on GitHub rather than a release tarball/zip. https://github.com/facebook/wangle/commit/2c55f2bdcc84216c26c6058e754b874c3029e39f